### PR TITLE
Add basic type hints to the API class, add comment to CompiledRouter …

### DIFF
--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -36,6 +36,7 @@ package namespace::
 """
 
 from datetime import datetime
+from typing import Union, Optional, Dict, List, Callable, Iterable, Any
 
 from falcon import util
 from falcon.http_error import HTTPError, NoRepresentation, \
@@ -87,7 +88,11 @@ class HTTPBadRequest(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, title=None, description=None, headers=None, **kwargs):
+    # NOTE(jxub) can title and description be optional?
+    def __init__(self, title: Optional[str] = None,
+                 description: Optional[str] = None,
+                 headers: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None,
+                 **kwargs: Any):
         super(HTTPBadRequest, self).__init__(status.HTTP_400, title,
                                              description, headers, **kwargs)
 
@@ -150,7 +155,11 @@ class HTTPUnauthorized(HTTPError):
 
     """
 
-    def __init__(self, title=None, description=None, challenges=None, headers=None, **kwargs):
+    def __init__(self, title: Optional[str] = None,
+                 description: Optional[str] = None,
+                 challenges: Iterable[str]=None,
+                 headers: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None,
+                 **kwargs: Any):
         if headers is None:
             headers = {}
 

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -14,14 +14,12 @@
 
 """Default routing engine."""
 
-from collections import UserDict
 import keyword
 import re
 import textwrap
 
 from falcon.routing import converters
 from falcon.routing.util import map_http_methods, set_default_responders
-
 
 _TAB_STR = ' ' * 4
 _FIELD_PATTERN = re.compile(
@@ -82,7 +80,7 @@ class CompiledRouter:
         self._find = self._compile()
 
     @property
-    def options(self):
+    def options(self):  # NOTE(jxub): CompiledRouterOptions works only with `from __future__ import annotations`
         return self._options
 
     @property

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -14,12 +14,14 @@
 
 """Default routing engine."""
 
+from collections import UserDict
 import keyword
 import re
 import textwrap
 
 from falcon.routing import converters
 from falcon.routing.util import map_http_methods, set_default_responders
+
 
 _TAB_STR = ' ' * 4
 _FIELD_PATTERN = re.compile(


### PR DESCRIPTION
…regarding the limitations of typing in versions of Python < 3.7

Hi, this is a basic first PR in order to get some suggestions and critiques going.